### PR TITLE
Lagt til alternative adresser for blog-poster

### DIFF
--- a/content/blog-posts/interpolering.md
+++ b/content/blog-posts/interpolering.md
@@ -1,4 +1,5 @@
 :page/title Interpolering i en verden hvor alt er data
+:page/alt-uris ["/interpolasjon/"]
 :blog-post/author {:person/id :person/magnar}
 :blog-post/published #time/ldt "2024-08-20T09:00:00"
 :blog-post/tags [:clojure :data :webutvikling]

--- a/resources/schema.edn
+++ b/resources/schema.edn
@@ -24,6 +24,14 @@
   :db/valueType :db.type/ref
   :db/cardinality :db.cardinality/one}
 
+ {:db/ident :page/alt-uris
+  :db/valueType :db.type/string
+  :db/cardinality :db.cardinality/many}
+
+ {:db/ident :page/redirect-uri
+  :db/valueType :db.type/string
+  :db/cardinality :db.cardinality/one}
+
  {:db/ident :series/id
   :db/valueType :db.type/keyword
   :db/unique :db.unique/identity

--- a/src/parenteser/ingest.clj
+++ b/src/parenteser/ingest.clj
@@ -43,10 +43,17 @@
         (update :open-graph/title #(or % (:page/title blog-post)))
         (update :open-graph/description #(or % (:blog-post/description blog-post))))))
 
+(defn ingest-blog-post-pages [blog-post]
+  (let [page (ingest-blog-post blog-post)]
+    (into [page]
+          (for [alt-uri (:page/alt-uris blog-post)]
+            {:page/redirect-uri (:page/uri page)
+             :page/uri alt-uri}))))
+
 (defn create-tx [file-name datas]
   (cond->> datas
     (re-find #"^blog-posts(-en)?\/" file-name)
-    (map ingest-blog-post)))
+    (mapcat ingest-blog-post-pages)))
 
 (defn get-tag-name-fixes [db]
   (for [tag (->> (d/q '[:find [?e ...]

--- a/src/parenteser/pages.clj
+++ b/src/parenteser/pages.clj
@@ -13,16 +13,21 @@
    {:title [:i18n ::not-found-title]}
    [:h1 [:i18n ::not-found-heading]]))
 
+(defn render-redirect [page]
+  {:status 302
+   :headers {"Location" (:page/redirect-uri page)}})
+
 (defn render-page [_req page]
-  (if-let [f (case (:page/kind page)
-               :page.kind/frontpage frontpage/render-frontpage
-               :page.kind/blog-post blog-post-page/render-blog-post
-               :page.kind/series series-page/render-series-page
-               :page.kind/rss-feed rss/blog-post-feed
-               :page.kind/tag tag/render-tag-page
-               nil)]
-    (f page)
-    (render-404 page)))
+  (let [f (case (:page/kind page)
+            :page.kind/frontpage frontpage/render-frontpage
+            :page.kind/blog-post blog-post-page/render-blog-post
+            :page.kind/series series-page/render-series-page
+            :page.kind/rss-feed rss/blog-post-feed
+            :page.kind/tag tag/render-tag-page
+            nil)]
+    (cond f (f page)
+          (:page/redirect-uri page) (render-redirect page)
+          :else (render-404 page))))
 
 (comment
 

--- a/test/parenteser/ingest_test.clj
+++ b/test/parenteser/ingest_test.clj
@@ -9,6 +9,14 @@
                :page/uri)
            "/lange-flate-filer/")))
 
+  (testing "Adds redirect URIs"
+    (is (= (-> {:page/uri "/blog-posts/skrivefeil/"
+                :page/alt-uris ["/skriveleif/"]}
+               sut/ingest-blog-post-pages
+               (->> (map #(select-keys % [:page/redirect-uri :page/uri]))))
+           [{:page/uri "/skrivefeil/"}
+            {:page/uri "/skriveleif/" :page/redirect-uri "/skrivefeil/"}])))
+
   (testing "Turns tags into refs"
     (is (= (-> {:blog-post/tags [:clojure :html]}
                sut/ingest-blog-post


### PR DESCRIPTION
Dette tillater at man kan spesifisere adresser som omadresserer
til den kanoniske adressen til blog-posten.
