### PR TITLE
Legg til -e etter echo i terminal kos

### DIFF
--- a/content/blog-posts/terminal-kos.md
+++ b/content/blog-posts/terminal-kos.md
@@ -23,9 +23,10 @@ du vil fargelegge noe tekst rødt kan du prefikse teksten med `\033[31m`. Prøv
 f.eks. å kjøre denne i din foretrukne terminal:
 
 ```
-$ echo "\033[31mDenne teksten er rød"
+$ echo -e "\033[31mDenne teksten er rød"
 ```
 
+- `-e` sørger for at `echo` tolker *backslash escapes* fremfor å gjengi dem ordrett
 - `\033` starter escape sekvensen
 - `[..m` forteller terminalen at du vil farge teksten som kommer etter (litt
   forenklet)
@@ -35,7 +36,7 @@ $ echo "\033[31mDenne teksten er rød"
 gøy kan du prøve denne:
 
 ```
-echo "Det \033[31msmalt\! \033[34mBukken\033[0m stupte \033[32mbums\033[0m i \033[35mbakken\033[0m."
+echo -e "Det \033[31msmalt\! \033[34mBukken\033[0m stupte \033[32mbums\033[0m i \033[35mbakken\033[0m."
 ```
 
 > Fantastisk 🎨


### PR DESCRIPTION
Hei!


## Problem 
Jeg tok oppfordringen i [terminal kos](https://parenteser.mattilsynet.io/terminal-kos/) og kjørte den oppgitte i kommandoen i min foretrukne terminal. Dessverre forble det kjedelig og fargeløst:
<img width="738" alt="echo i fish" src="https://github.com/user-attachments/assets/390a0fb9-f5d2-471d-a48e-a23d42150c1a" />

Greit nok, det er kanskje ikke så vanlig å bruke `fish`, så da prøvde jeg heller i `bash`. Dessverre:
<img width="738" alt="echo i bash" src="https://github.com/user-attachments/assets/4a6d54f4-6c22-47e1-a060-dbb40adaa733" />


I `zsh` går det som håpet, så lenge du er på en mac. Da jeg testet på Linux fikk jeg samme resultat som i skjermbildene over.

## Fiks

Men om en bruker `-e` for å [enable interpretation of backslash escapes](https://linux.die.net/man/1/echo) blir teksten rød! Det samme flagget er [støttet i `fish`](https://fishshell.com/docs/current/cmds/echo.html).

### `fish`
<img width="738" alt="image" src="https://github.com/user-attachments/assets/985b492e-2f5f-48e1-ac35-1bfd7d2bcb8e" />


### `bash`
<img width="738" alt="echo -e i bash" src="https://github.com/user-attachments/assets/bc40700d-c817-4828-ac41-d21e074ad07f" />

En artig side-effekt i både `bash` og `fish` er at teksten _forblir_ rød, men det er kanskje ikke så farlig siden en alltids kan åpne en ny terminalsesjon, eller evt kjøre `echo -e "\033[0m"` som nevnt i bloggposten.

### `zsh`

<img width="738" alt="echo -e i zsh" src="https://github.com/user-attachments/assets/7e8daeea-63cb-4558-9f2c-ff10261bb7f8" />
